### PR TITLE
Test fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Proof of concept of fully-featured Kafka-based storage for Zipkin.
 
 *This is not production ready at the moment. Things will change!*
 
-## Design goals
+## Design goals 
 
 * Remove need for additional storage when Kafka is in place.
 * Provide a fast and reliable storage that enable extensability via Kafka

--- a/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageIT.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageIT.java
@@ -48,6 +48,7 @@ public class KafkaStorageIT {
     public void should_consume_spans() throws InterruptedException {
         StorageComponent storage = new KafkaStorage.Builder().bootstrapServers(kafka.getBootstrapServers())
                 .stateStoreDir("target/kafka-streams/" + Instant.now().getEpochSecond())
+                .spansTopic("topic")
                 .build();
         Thread.sleep(1000);
         Span root = Span.newBuilder().traceId("a").id("a").timestamp(TODAY).duration(10).build();
@@ -84,6 +85,7 @@ public class KafkaStorageIT {
 
         StorageComponent storage = new KafkaStorage.Builder().bootstrapServers(kafka.getBootstrapServers())
                 .stateStoreDir("target/kafka-streams/" + Instant.now().getEpochSecond())
+                .spansTopic("topic")
                 .build();
         Thread.sleep(3000);
         Span root = Span.newBuilder().traceId("a").id("a").timestamp(TODAY).duration(10).build();
@@ -105,6 +107,7 @@ public class KafkaStorageIT {
 
         StorageComponent storage = new KafkaStorage.Builder().bootstrapServers(kafka.getBootstrapServers())
                 .stateStoreDir("target/kafka-streams/" + Instant.now().getEpochSecond())
+                .spansTopic("topic")
                 .build();
         Thread.sleep(3000);
         Span root = Span.newBuilder().traceId("a").id("a").localEndpoint(Endpoint.newBuilder().serviceName("service_a").build()).name("operation_a").timestamp(TODAY).duration(10).build();


### PR DESCRIPTION
Fix: override default topic

After fix each test is successful separately. But there are  still deadlock between tests. 
Lock held by virtual machine where kafka container is running. 


```
java.lang.RuntimeException: org.apache.lucene.store.LockObtainFailedException: Lock held by this virtual machine: /private/tmp/lucene-index/write.lock

	at zipkin2.storage.kafka.internal.stores.IndexStateStore$Builder.build(IndexStateStore.java:87)
	at zipkin2.storage.kafka.internal.stores.IndexStateStore$Builder.build(IndexStateStore.java:36)
	at org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.rewriteTopology(InternalTopologyBuilder.java:359)
	at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:664)
	at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:624)
	at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:534)
	at zipkin2.storage.kafka.KafkaStorage.<init>(KafkaStorage.java:215)
	at zipkin2.storage.kafka.KafkaStorage$Builder.build(KafkaStorage.java:135)
	at zipkin2.storage.kafka.KafkaStorageIT.should_get_service(KafkaStorageIT.java:111)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.testcontainers.containers.FailureDetectingExternalResource$1.evaluate(FailureDetectingExternalResource.java:30)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: org.apache.lucene.store.LockObtainFailedException: Lock held by this virtual machine: /private/tmp/lucene-index/write.lock
	at org.apache.lucene.store.NativeFSLockFactory.obtainFSLock(NativeFSLockFactory.java:139)
	at org.apache.lucene.store.FSLockFactory.obtainLock(FSLockFactory.java:41)
	at org.apache.lucene.store.BaseDirectory.obtainLock(BaseDirectory.java:45)
	at org.apache.lucene.index.IndexWriter.<init>(IndexWriter.java:727)
	at zipkin2.storage.kafka.internal.stores.IndexStateStore.<init>(IndexStateStore.java:131)
	at zipkin2.storage.kafka.internal.stores.IndexStateStore$Builder.build(IndexStateStore.java:85)
	... 32 more
```