### PR TITLE
Fresh results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ build: license-header
 	${MAVEN} clean install -DskipTests
 
 .PHONY: test
-test: build
+test:
 	${MAVEN} test verify
 
 .PHONY: zipkin-local

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
@@ -211,9 +211,9 @@ public class KafkaSpanStore implements SpanStore, ServiceAndSpanNames {
         }
       });
       traces.sort(Comparator.comparing(o -> o.get(0).timestamp()));
-      // TODO check if we should reverse
+      Collections.reverse(traces); // return most recent traces
       LOG.debug("Traces found from query {}: {}", queryRequest, traces.size());
-      return traces.subList(0, queryRequest.limit());
+      return traces.subList(0, queryRequest.limit() >= traces.size() ? traceIds.size() : queryRequest.limit());
     }
 
     @Override

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
@@ -212,8 +212,7 @@ public class KafkaSpanStore implements SpanStore, ServiceAndSpanNames {
           }
         });
       }
-      traces.sort(Comparator.comparing(o -> o.get(0).timestamp()));
-      Collections.reverse(traces); // return most recent traces
+      traces.sort(Comparator.<List<Span>>comparingLong(o -> o.get(0).timestampAsLong()).reversed());
       LOG.debug("Traces found from query {}: {}", request, traces.size());
       return traces.subList(0,
           request.limit() >= traces.size() ? traceIds.size() : request.limit());

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
@@ -112,10 +112,12 @@ public class KafkaSpanStore implements SpanStore, ServiceAndSpanNames {
 
     @Override public List<String> query() {
       List<String> serviceNames = new ArrayList<>();
-      serviceStore.all().forEachRemaining(keyValue -> {
-        // double check service names are unique
-        if (!serviceNames.contains(keyValue.value)) serviceNames.add(keyValue.value);
-      });
+      try (KeyValueIterator<String, String> all = serviceStore.all()) {
+        all.forEachRemaining(keyValue -> {
+          // double check service names are unique
+          if (!serviceNames.contains(keyValue.value)) serviceNames.add(keyValue.value);
+        });
+      }
       // comply with Zipkin API as service names are required to be ordered lexicographically
       Collections.sort(serviceNames);
       return serviceNames;
@@ -179,46 +181,47 @@ public class KafkaSpanStore implements SpanStore, ServiceAndSpanNames {
   static class GetTracesCall extends KafkaStreamsStoreCall<List<List<Span>>> {
     final ReadOnlyKeyValueStore<String, List<Span>> tracesStore;
     final ReadOnlyKeyValueStore<Long, Set<String>> traceIdsByTsStore;
-    final QueryRequest queryRequest;
+    final QueryRequest request;
 
     GetTracesCall(
         ReadOnlyKeyValueStore<String, List<Span>> tracesStore,
         ReadOnlyKeyValueStore<Long, Set<String>> traceIdsByTsStore,
-        QueryRequest queryRequest) {
+        QueryRequest request) {
       this.tracesStore = tracesStore;
       this.traceIdsByTsStore = traceIdsByTsStore;
-      this.queryRequest = queryRequest;
+      this.request = request;
     }
 
     @Override public List<List<Span>> query() {
       List<List<Span>> traces = new ArrayList<>();
       List<String> traceIds = new ArrayList<>();
       // milliseconds to microseconds
-      long from = (queryRequest.endTs() - queryRequest.lookback()) * 1000;
-      long to = queryRequest.endTs() * 1000;
+      long from = (request.endTs() - request.lookback()) * 1000;
+      long to = request.endTs() * 1000;
       // first index
-      KeyValueIterator<Long, Set<String>> spanIds = traceIdsByTsStore.range(from, to);
-      spanIds.forEachRemaining(keyValue -> {
-        for (String traceId : keyValue.value) {
-          if (!traceIds.contains(traceId)) {
-          //if (!traceIds.contains(traceId) && traces.size() < queryRequest.limit()) {
-            List<Span> spans = tracesStore.get(traceId);
-            if (spans != null && queryRequest.test(spans)) { // apply filters
-              traceIds.add(traceId); // adding to check if we have already add it later
-              traces.add(spans);
+      try (KeyValueIterator<Long, Set<String>> spanIds = traceIdsByTsStore.range(from, to)) {
+        spanIds.forEachRemaining(keyValue -> {
+          for (String traceId : keyValue.value) {
+            if (!traceIds.contains(traceId)) {
+              List<Span> spans = tracesStore.get(traceId);
+              if (spans != null && request.test(spans)) { // apply filters
+                traceIds.add(traceId); // adding to check if we have already add it later
+                traces.add(spans);
+              }
             }
           }
-        }
-      });
+        });
+      }
       traces.sort(Comparator.comparing(o -> o.get(0).timestamp()));
       Collections.reverse(traces); // return most recent traces
-      LOG.debug("Traces found from query {}: {}", queryRequest, traces.size());
-      return traces.subList(0, queryRequest.limit() >= traces.size() ? traceIds.size() : queryRequest.limit());
+      LOG.debug("Traces found from query {}: {}", request, traces.size());
+      return traces.subList(0,
+          request.limit() >= traces.size() ? traceIds.size() : request.limit());
     }
 
     @Override
     public Call<List<List<Span>>> clone() {
-      return new GetTracesCall(tracesStore, traceIdsByTsStore, queryRequest);
+      return new GetTracesCall(tracesStore, traceIdsByTsStore, request);
     }
   }
 
@@ -226,9 +229,7 @@ public class KafkaSpanStore implements SpanStore, ServiceAndSpanNames {
     final ReadOnlyKeyValueStore<String, List<Span>> traceStore;
     final String traceId;
 
-    GetTraceCall(
-        ReadOnlyKeyValueStore<String, List<Span>> traceStore,
-        String traceId) {
+    GetTraceCall(ReadOnlyKeyValueStore<String, List<Span>> traceStore, String traceId) {
       this.traceStore = traceStore;
       this.traceId = traceId;
     }

--- a/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/KafkaSpanStore.java
@@ -198,7 +198,7 @@ public class KafkaSpanStore implements SpanStore, ServiceAndSpanNames {
       // milliseconds to microseconds
       long from = (request.endTs() - request.lookback()) * 1000;
       long to = request.endTs() * 1000;
-      long checkpoint = to - (60 * 1000 * 1000); // 1 min before upper bound
+      long checkpoint = to - (30 * 1000 * 1000); // 30 sec before upper bound
       if (checkpoint <= from) { // do one run
         try (KeyValueIterator<Long, Set<String>> spanIds = traceIdsByTsStore.range(from, to)) {
           spanIds.forEachRemaining(keyValue -> {

--- a/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageIT.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageIT.java
@@ -181,7 +181,7 @@ class KafkaStorageIT {
             traces =
                 spanStore.getTraces(QueryRequest.newBuilder()
                     .endTs(TODAY + 1)
-                    .lookback(Duration.ofMinutes(1).toMillis())
+                    .lookback(Duration.ofSeconds(30).toMillis())
                     .serviceName("svc_a")
                     .limit(10)
                     .build())
@@ -201,7 +201,7 @@ class KafkaStorageIT {
             traces =
                 spanStore.getTraces(QueryRequest.newBuilder()
                     .endTs(TODAY + 1)
-                    .lookback(Duration.ofMinutes(2).toMillis())
+                    .lookback(Duration.ofMinutes(1).toMillis())
                     .limit(1)
                     .build())
                     .execute();

--- a/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageIT.java
+++ b/storage/src/test/java/zipkin2/storage/kafka/KafkaStorageIT.java
@@ -174,7 +174,7 @@ class KafkaStorageIT {
     SpanStore spanStore = storage.spanStore();
     ServiceAndSpanNames serviceAndSpanNames = storage.serviceAndSpanNames();
     // Then: services names are searchable
-    await().atMost(30, TimeUnit.SECONDS)
+    await().atMost(10, TimeUnit.SECONDS)
         .until(() -> {
           List<List<Span>> traces = new ArrayList<>();
           try {
@@ -194,14 +194,14 @@ class KafkaStorageIT {
           return traces.size() == 1
               && traces.get(0).size() == 2; // Trace is found and has two spans
         });
-    await().atMost(30, TimeUnit.SECONDS)
+    await().atMost(10, TimeUnit.SECONDS)
         .until(() -> {
           List<List<Span>> traces = new ArrayList<>();
           try {
             traces =
                 spanStore.getTraces(QueryRequest.newBuilder()
                     .endTs(TODAY + 1)
-                    .lookback(Duration.ofMinutes(1).toMillis())
+                    .lookback(Duration.ofMinutes(2).toMillis())
                     .limit(1)
                     .build())
                     .execute();


### PR DESCRIPTION
Fix #33 

This PR includes an attempt to solve the "return oldest" issue by creating a bucketed range query procedure and validate on every bucket if we have enough traces to return a result, instead of testing every trace on request range, or return first results.