### PR TITLE
Fix: Remove expensive changelog topics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@
 
 FROM alpine
 
+ARG VERSION=master-SNAPSHOT
 ENV USER jeqo
-ENV VERSION 0.5.3
 
 WORKDIR /zipkin
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 
 OPEN := 'xdg-open'
 MAVEN := './mvnw'
-VERSION := '0.5.4-SNAPSHOT'
+VERSION := 'faster-start-SNAPSHOT'
 IMAGE_NAME := 'jeqo/zipkin-kafka'
 
 .PHONY: run
@@ -23,11 +23,11 @@ kafka-topics:
 
 .PHONY: docker-build
 docker-build:
-	docker build -t ${IMAGE_NAME}:latest .
-	docker build -t ${IMAGE_NAME}:${VERSION} .
+	docker build --build-arg VERSION=${VERSION} -t ${IMAGE_NAME}:latest .
+	docker build --build-arg VERSION=${VERSION} -t ${IMAGE_NAME}:${VERSION} .
 
 .PHONY: docker-push
-docker-push: docker-build
+docker-push:
 	docker push ${IMAGE_NAME}:latest
 	docker push ${IMAGE_NAME}:${VERSION}
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 
 OPEN := 'xdg-open'
 MAVEN := './mvnw'
-VERSION := 'faster-start-SNAPSHOT'
+VERSION := 'master-SNAPSHOT'
 IMAGE_NAME := 'jeqo/zipkin-kafka'
 
 .PHONY: run

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/DependencyStoreTopologySupplier.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/DependencyStoreTopologySupplier.java
@@ -55,15 +55,17 @@ public class DependencyStoreTopologySupplier implements Supplier<Topology> {
     StreamsBuilder builder = new StreamsBuilder();
 
     // Dependency links window store
-    builder.addStateStore(Stores.windowStoreBuilder(
-        Stores.persistentWindowStore(
-            DEPENDENCIES_STORE_NAME,
-            dependencyTtl,
-            dependencyWindowSize,
-            false),
-        Serdes.String(),
-        dependencyLinkSerde
-    ));
+    builder.addStateStore(
+        // Disabling logging to avoid long starting times
+        Stores.windowStoreBuilder(
+            Stores.persistentWindowStore(
+                DEPENDENCIES_STORE_NAME,
+                dependencyTtl,
+                dependencyWindowSize,
+                false),
+            Serdes.String(),
+            dependencyLinkSerde
+        ).withLoggingDisabled());
     // Consume dependency links stream
     builder.stream(dependencyTopicName, Consumed.with(Serdes.String(), dependencyLinkSerde))
         // Storage

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStoreTopologySupplier.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStoreTopologySupplier.java
@@ -107,7 +107,7 @@ public class TraceStoreTopologySupplier implements Supplier<Topology> {
         .addStateStore(Stores.keyValueStoreBuilder(
             Stores.persistentKeyValueStore(AUTOCOMPLETE_TAGS_STORE_NAME),
             Serdes.String(),
-            namesSerde));
+            namesSerde).withLoggingDisabled());
     // Traces stream
     KStream<String, List<Span>> spansStream = builder
         .stream(

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStoreTopologySupplier.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStoreTopologySupplier.java
@@ -83,7 +83,7 @@ public class TraceStoreTopologySupplier implements Supplier<Topology> {
             Stores.persistentKeyValueStore(TRACES_STORE_NAME),
             Serdes.String(),
             spansSerde).withLoggingDisabled())
-        // Logging disabled to avoid long starting times
+        // Disabling logging to avoid long starting times
         .addStateStore(Stores.keyValueStoreBuilder(
             Stores.persistentKeyValueStore(SPAN_IDS_BY_TS_STORE_NAME),
             Serdes.Long(),

--- a/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStoreTopologySupplier.java
+++ b/storage/src/main/java/zipkin2/storage/kafka/streams/TraceStoreTopologySupplier.java
@@ -148,9 +148,10 @@ public class TraceStoreTopologySupplier implements Supplier<Topology> {
                       tracesStore.delete(traceId); // clean traces store
                     }
                   });
-                  LOG.info("Traces deletion emitted at {}, approx. number of traces stored {}",
+                  LOG.info("Traces deletion emitted at {}, approx. number of traces stored {} - partition: {}",
                       Instant.ofEpochMilli(to).atZone(ZoneId.systemDefault()),
-                      tracesStore.approximateNumEntries());
+                      tracesStore.approximateNumEntries(),
+                      context.partition());
                 }
               }
             });


### PR DESCRIPTION
Currently Stores have a default configuration, leading to compacted `*-changelog` topics to be created and used during initialization to restore state. This leads to slower startup times and high resource consumption depending on the amount of data we have.

Given that the source of this stores are Kafka topics and state is persisted on disk, this PR is proposing to remove this setting on traces/dependencies/tags related stores as are unbounded; and turn service names related stores into memory. 